### PR TITLE
Fixed dependencies that prevent ckgapp from running

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -56,3 +56,5 @@ rst2pdf==0.98
 nbsphinx>=0.8.0
 ipykernel>=5.4.3
 eventlet==0.25.1
+itsdangerous==2.0.1
+reportlab==3.6.6


### PR DESCRIPTION
Current master branch, ckgapp won't launch and will display internal server error on port 8050 due to dependency compatibility issues after build docker image. This PR fixed dependency versions.